### PR TITLE
Replace dotenv with dotenv-safe

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const express = require('express')
 const mongoose = require('mongoose')
 const bodyParser = require('body-parser')
 const cors = require('cors')
-require('dotenv').config()
+require('dotenv-safe').config()
 
 const authRoute = require('./routes/auth.js')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -887,9 +887,17 @@
       }
     },
     "dotenv": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
-      "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "dotenv-safe": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-safe/-/dotenv-safe-8.2.0.tgz",
+      "integrity": "sha512-uWwWWdUQkSs5a3mySDB22UtNwyEYi0JtEQu+vDzIqr9OjbDdC2Ip13PnSpi/fctqlYmzkxCeabiyCAOROuAIaA==",
+      "requires": {
+        "dotenv": "^8.2.0"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bcrypt": "^3.0.6",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
-    "dotenv": "^8.1.0",
+    "dotenv-safe": "^8.2.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.6.9",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,7 +2,7 @@ const { Router } = require('express')
 const { hash, compare } = require('bcrypt')
 const { sign } = require('jsonwebtoken')
 const mongoose = require('mongoose')
-require('dotenv').config()
+require('dotenv-safe').config()
 
 const { API_SECRET } = process.env
 const router = Router()


### PR DESCRIPTION
## What's done?
`dotenv-safe` makes it possible to make use of the .env.example file. Now we will be warned if some environment variable is defined in .env.example but not in .env ❤️ 